### PR TITLE
Return null to ignore event

### DIFF
--- a/src/domain/event/matcher/match-event-type.matcher.ts
+++ b/src/domain/event/matcher/match-event-type.matcher.ts
@@ -33,6 +33,7 @@ export const matchFirmwareUpdatedEvent = (event: Event): event is FirmwareUpdate
     return event instanceof FirmwareUpdatedEvent;
 };
 
-export const matchAndTransformFirmwareUpdate = (event: Event): [IBoardDataValues] => {
-    if (matchFirmwareUpdatedEvent(event)) return [event.dataValues];
-};
+export const matchAndTransformFirmwareUpdate = (event: Event): [IBoardDataValues] | null => 
+    !matchFirmwareUpdatedEvent(event) ? null : [ event.dataValues ]
+    ;
+


### PR DESCRIPTION
When the event is to be ignored, null should be returned.
It works as well if you return undefined though but it is not correct type-wise.

Cheers mate